### PR TITLE
feat: Implement StudentWork::BulkCreationService using insert_all

### DIFF
--- a/app/models/student_work.rb
+++ b/app/models/student_work.rb
@@ -4,8 +4,10 @@ class StudentWork < ApplicationRecord
 
   # Associations
   belongs_to :assignment
+  belongs_to :selected_document
   has_many :feedback_items, as: :feedbackable, dependent: :destroy
   has_many :student_work_checks, dependent: :destroy
+  has_many :student_work_criterion_levels, dependent: :destroy
 
   enum :status, { pending: 0, processing: 1, completed: 2, failed: 3 }
 

--- a/app/services/student_work/bulk_creation_service.rb
+++ b/app/services/student_work/bulk_creation_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Creates multiple StudentWork records from SelectedDocument records
+# within a single database transaction.
+class StudentWork::BulkCreationService
+  def self.call(assignment:, selected_documents:)
+    new(assignment: assignment, selected_documents: selected_documents).call
+  end
+
+  attr_reader :assignment, :selected_documents
+
+  # @param assignment [Assignment] The assignment these student works belong to.
+  # @param selected_documents [Array<SelectedDocument>] The documents to create work records for.
+  def initialize(assignment:, selected_documents:)
+    @assignment = assignment
+    @selected_documents = selected_documents
+  end
+
+  # Executes the bulk creation process.
+  # @return [Boolean] true if successful, false otherwise (or raises error)
+  def call
+    student_works_attributes = selected_documents.map do |doc|
+      {
+        assignment_id: assignment.id,
+        selected_document_id: doc.id,
+        status: StudentWork.statuses[:pending]
+      }
+    end
+
+    return false if student_works_attributes.empty?
+
+    # Although insert_all is atomic, keep transaction for explicit control
+    # and potential future steps within the same transaction.
+    ActiveRecord::Base.transaction do
+      StudentWork.insert_all(student_works_attributes)
+    end
+
+    true # Return true on success
+  rescue StandardError => e # Catch potential DB errors from insert_all
+    # Log error or handle as needed
+    Rails.logger.error "StudentWork bulk creation failed during insert_all: #{e.message}"
+    false # Return false on failure
+  end
+end

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@ Implemented bulk creation for assignment-selected Google Docs and removed unique
 - Implemented `SelectedDocument::BulkCreationService` for efficient bulk creation of selected documents associated with assignments, using `insert_all!` for performance.
 - Service enforces a maximum of 35 documents per assignment and stores doc ID, URL, and title.
 - Added comprehensive tests for valid creation, limit enforcement, and transactional integrity.
+- Implemented `StudentWork::BulkCreationService` for efficient creation of multiple `StudentWork` records from `SelectedDocument` records using `insert_all` (Task 17).
+- Implemented `Assignments::BulkCreationService` to create Assignment records for each selected Google Document (Task 15).
+- Added `google_doc_id` and `url` to `selected_documents` table (Task 16).
 ### Changed
 - Removed unique index on `google_doc_id` from `selected_documents` to allow the same Google Doc to be selected for multiple assignments.
 - Updated migration and schema to reflect non-unique index on `google_doc_id`.

--- a/db/migrate/20250424035749_add_selected_document_to_student_works.rb
+++ b/db/migrate/20250424035749_add_selected_document_to_student_works.rb
@@ -1,0 +1,5 @@
+class AddSelectedDocumentToStudentWorks < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :student_works, :selected_document, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_24_032754) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_24_035749) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -285,7 +285,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_24_032754) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "selected_document_id", null: false
     t.index ["assignment_id"], name: "index_student_works_on_assignment_id"
+    t.index ["selected_document_id"], name: "index_student_works_on_selected_document_id"
     t.index ["status"], name: "index_student_works_on_status"
   end
 
@@ -334,5 +336,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_24_032754) do
   add_foreign_key "student_work_criterion_levels", "levels"
   add_foreign_key "student_work_criterion_levels", "student_works"
   add_foreign_key "student_works", "assignments"
+  add_foreign_key "student_works", "selected_documents"
   add_foreign_key "user_tokens", "users"
 end

--- a/tasks/tasks.json
+++ b/tasks/tasks.json
@@ -299,7 +299,7 @@
       "id": 17,
       "title": "Create StudentWork::BulkCreationService",
       "description": "Implement service for creating multiple student work records in one transaction.",
-      "status": "in-progress",
+      "status": "done",
       "dependencies": [
         7,
         16

--- a/test/fixtures/selected_documents.yml
+++ b/test/fixtures/selected_documents.yml
@@ -1,17 +1,17 @@
 doc_1:
   assignment: valid_assignment
-  google_doc_id: "goog_doc_id_111"
-  title: "Essay Draft 1"
-  url: "https://docs.google.com/document/d/goog_doc_id_111/edit"
+  google_doc_id: "google_doc_id_1"
+  title: "Document 1 Title"
+  url: "https://docs.google.com/document/d/google_doc_id_1/edit"
 
 doc_2:
   assignment: valid_assignment
-  google_doc_id: "goog_doc_id_222"
-  title: "Essay Draft 2"
-  url: "https://docs.google.com/document/d/goog_doc_id_222/edit"
+  google_doc_id: "google_doc_id_2" # Needs to be unique if DB constraint exists, but we removed it. Still good practice.
+  title: "Document 2 Title"
+  url: "https://docs.google.com/document/d/google_doc_id_2/edit"
 
 doc_3:
   assignment: valid_assignment
-  google_doc_id: "goog_doc_id_333"
-  title: "Essay Draft 3"
-  url: "https://docs.google.com/document/d/goog_doc_id_333/edit"
+  google_doc_id: "google_doc_id_333"
+  title: "Document 3 Title"
+  url: "https://docs.google.com/document/d/google_doc_id_333/edit"

--- a/test/fixtures/student_works.yml
+++ b/test/fixtures/student_works.yml
@@ -1,8 +1,10 @@
 one:
   assignment: valid_assignment # From assignments.yml
+  selected_document: doc_1    # Added reference
   status: :pending
 
 two:
   assignment: valid_assignment # From assignments.yml
+  selected_document: doc_2    # Added reference
   qualitative_feedback: "Excellent work!"
-  status: :completed 
+  status: :completed

--- a/test/services/student_work/bulk_creation_service_test.rb
+++ b/test/services/student_work/bulk_creation_service_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StudentWork::BulkCreationServiceTest < ActiveSupport::TestCase
+  setup do
+    # Setup fixtures for assignment and selected documents
+    @assignment = assignments(:valid_assignment)
+    @selected_doc1 = selected_documents(:doc_1)
+    @selected_doc2 = selected_documents(:doc_2)
+    @selected_documents = [ @selected_doc1, @selected_doc2 ]
+  end
+
+  test "creates student work records for valid selected documents using insert_all" do
+    # Setup: Ensure no pre-existing work for these selected docs to avoid conflicts
+    StudentWork.where(selected_document: @selected_documents).destroy_all
+    assert StudentWork.where(selected_document: @selected_documents).empty?, "Pre-existing StudentWork should be deleted"
+
+    # Exercise
+    assert_difference "StudentWork.count", @selected_documents.size do
+      service = StudentWork::BulkCreationService.new(assignment: @assignment, selected_documents: @selected_documents)
+      assert service.call, "Service call should return true"
+    end
+
+    # Verify
+    created_works = StudentWork.where(selected_document: @selected_documents).order(:selected_document_id)
+
+    assert_equal 2, created_works.size
+    assert_equal @selected_doc1, created_works[0].selected_document
+    assert_equal @assignment, created_works[0].assignment
+    assert created_works[0].pending?, "Status should be pending for work related to doc1"
+
+    assert_equal @selected_doc2, created_works[1].selected_document
+    assert_equal @assignment, created_works[1].assignment
+    assert created_works[1].pending?, "Status should be pending for work related to doc2"
+  end
+end


### PR DESCRIPTION
## Summary

This PR implements the `StudentWork::BulkCreationService` to enable the efficient creation of multiple `StudentWork` records from a set of `SelectedDocument` records. This addresses Task 17.

## Changes

*   **Created `StudentWork::BulkCreationService`**:
    *   Located at `app/services/student_work/bulk_creation_service.rb`.
    *   Takes an `Assignment` and an array of `SelectedDocument` objects during initialization.
    *   The `call` method uses `StudentWork.insert_all` within an `ActiveRecord::Base.transaction` block for efficient bulk insertion and atomicity.
    *   Sets the `status` to `:pending` and assigns the correct `assignment_id` and `selected_document_id` for each new record.
    *   Includes basic error handling and logging for `insert_all` failures.
*   **Model Updates (`StudentWork`)**:
    *   Added `belongs_to :selected_document` association.
    *   Added `has_many :student_work_criterion_levels, dependent: :destroy` to ensure proper cleanup during testing and deletion.
*   **Fixture Updates**:
    *   Updated `test/fixtures/student_works.yml` to include the required `selected_document` reference for existing fixtures (`:one`, `:two`).
    *   Cleaned up `test/fixtures/selected_documents.yml` to remove non-existent `word_count` field and ensure data consistency.
*   **Test Implementation (`StudentWork::BulkCreationServiceTest`)**:
    *   Created `test/services/student_work/bulk_creation_service_test.rb`.
    *   Implemented a test case following TDD principles:
        *   Initially failed with `NameError` (service not defined).
        *   Fixed fixture/schema mismatch (`word_count`).
        *   Failed with `AssertionError` (count didn't change).
        *   Implemented basic `create!` loop, then refactored to `insert_all`.
        *   Fixed test assertion logic that was finding old fixtures instead of new records due to status mismatch (`completed` vs `pending`).
        *   Added cleanup (`destroy_all`) to the test setup to prevent fixture conflicts.
        *   Resolved `InvalidForeignKey` error during test setup by adding the missing `dependent: :destroy` association to the `StudentWork` model.
    *   The final test verifies correct record count, associations, and initial `:pending` status for newly created records.
*   **Documentation**:
    *   Marked Task 17 as "done" in [tasks.json](cci:7://file:///Users/jesse/code/gradebot/tasks/tasks.json:0:0-0:0).
    *   Added an entry to [changelog.md](cci:7://file:///Users/jesse/code/gradebot/changelog.md:0:0-0:0).

## Testing

- Unit tests for `StudentWork::BulkCreationService` pass.
- Addressed various test failures during development related to fixtures, associations, and test logic.

## Related Task

- Closes #17