### PR TITLE
FIX: update docker file and assets.rb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN bundle exec bootsnap precompile app/ lib/
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
+# Verify assets were properly compiled
+RUN ls -la public/assets/
+
 
 
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,4 +7,4 @@ Rails.application.config.assets.version = "1.0"
 # Rails.application.config.assets.paths << Emoji.images_path
 
 # Explicitly compile stylesheets
-Rails.application.config.assets.precompile += %w[ prose.css all.css ]
+Rails.application.config.assets.precompile += %w[ prose.css ]


### PR DESCRIPTION
The two key changes you're committing are:

The Dockerfile change to verify assets are properly compiled
The simplified assets.rb configuration to explicitly precompile only prose.css
These address the likely root causes of your production styling issues:

The Dockerfile verification step will ensure that assets are properly compiled during the build process and give you visibility into what's actually being generated
The simplified assets configuration will let Rails handle the standard stylesheets correctly while still explicitly precompiling the custom prose.css file